### PR TITLE
Support TF_CLI_* Arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,8 @@ SHELL = /bin/bash
 
 PATH:=$(PATH):$(GOPATH)/bin
 
-include $(shell curl --silent -o .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 
+build: go/build
+	@exit 0
 
-.PHONY : go-get
-go-get:
-	go get
-
-
-.PHONY : go-build
-go-build: go-get
-	CGO_ENABLED=0 go build -v -o "./dist/bin/tfenv" *.go

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you answer "yes" to any of these questions, then look no further!
 * Have you ever wished you could easily pass environment variables to terraform *without* adding the `TF_VAR_` prefix?
 * Do you use [`chamber`](https://github.com/segmentio/chamber) and get annoyed when it transforms environment variables to uppercase?
 * Would you like to use common environment variables names with terraform? (e.g. `USER` or `AWS_REGION`)
+* Is there some argument to `terraform init` you want to specify with an environment variable? (e.g. a `-backend-config` property)
 
 **Yes?** Great! Then this utility is for you.
 
@@ -56,6 +57,29 @@ The `tfenv` utility will perform the following transformations:
   4. Prepend prefix (`TF_VAR_`)
 
 __NOTE__: `tfenv` will preserve the existing environment and add the new environment variables with `TF_VAR_`. This is because some terraform providers expect non-`TF_VAR_*` prefixed environment variables. Additionally, when using the `local-exec` provisioner, it's convenient to use regular environment variables. See our [`terraform-null-smtp-mail`](https://github.com/cloudposse/terraform-null-smtp-mail) module for an example of using this pattern.
+
+
+**But wait, there's more!**
+
+With `tfenv` we can surgically assign a value to any terraform argument using per-argument environment variables.
+
+For example, if you want to pass `-backend-config=bucket=terraform-state-bucket` to `terraform init`, then you would do the following:
+
+```
+export TF_CLI_INIT_BACKEND_CONFIG_BUCKET=terraform-state-bucket
+```
+
+Running `tfenv` will populate the `TF_CLI_ARGS_init=-backend-config=bucket=terraform-state-bucket`
+
+Multiple arguments can be specified.
+
+```
+export TF_CLI_INIT_FROM_MODULE=git::git@github.com:ImpactHealthio/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
+source <(tfenv)
+terraform init
+```
+
+Learn more about `TF_CLI_ARGS` and `TF_CLI_ARGS_*` in the [official documentation](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name).
 
 ## Usage
 
@@ -207,7 +231,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
 # tfenv [![Build Status](https://travis-ci.org/cloudposse/tfenv.svg?branch=master)](https://travis-ci.org/cloudposse/tfenv) [![Latest Release](https://img.shields.io/github/release/cloudposse/tfenv.svg)](https://github.com/cloudposse/tfenv/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
-Command line utility to transform environment variables for use with Terraform (e.g. `HOSTNAME` → `TF_VAR_hostname`)
+Command line utility to transform environment variables for use with Terraform.
+(e.g. `HOSTNAME` → `TF_VAR_hostname`)
 
-__NOTE__: `tfenv` is **not** a [terraform version manager](https://github.com/tfutils/tfenv).
+It can also intelligently map environment variables to terraform command line arguments (e.g. `TF_CLI_INIT_BACKEND_CONFIG_BUCKET=example` → `TF_CLI_ARGS_init=-backend-config=bucket=example`).
+
+__NOTE__: `tfenv` is **not** a [terraform version manager](https://github.com/tfutils/tfenv). It strictly manages environment variables.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -63,24 +63,6 @@ __NOTE__: `tfenv` will preserve the existing environment and add the new environ
 
 With `tfenv` we can surgically assign a value to any terraform argument using per-argument environment variables.
 
-For example, if you want to pass `-backend-config=bucket=terraform-state-bucket` to `terraform init`, then you would do the following:
-
-```
-export TF_CLI_INIT_BACKEND_CONFIG_BUCKET=terraform-state-bucket
-```
-
-Running `tfenv` will populate the `TF_CLI_ARGS_init=-backend-config=bucket=terraform-state-bucket`
-
-Multiple arguments can be specified.
-
-```
-export TF_CLI_INIT_FROM_MODULE=git::git@github.com:ImpactHealthio/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
-source <(tfenv)
-terraform init
-```
-
-Learn more about `TF_CLI_ARGS` and `TF_CLI_ARGS_*` in the [official documentation](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name).
-
 ## Usage
 
 
@@ -99,8 +81,57 @@ The basic usage looks like this. We're going to run some `command` and pass it `
 So for example, we can pass our current environment to terraform by simply running:
 
 ```sh
-    tfenv terraform plan
+tfenv terraform plan
 ```
+
+### Direnv
+
+You can use `tfenv` with direnv very easily. Running `tfenv` without any arguments will emit `export` statements.
+
+Example `.envrc`:
+
+```sh
+# Export terraform environment
+tfenv
+```
+
+### Bash
+
+Load the terraform environment into your shell.
+
+Just add the following into your shell script:
+
+```sh
+source <(tfenv)
+```
+
+### Terraform Args
+
+With `tfenv` we can populate the [`TF_CLI_ARGS` and `TF_CLI_ARGS_*` environment variables](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name) automatically. This makes it easy to toggle settings. 
+
+For example, if you want to pass `-backend-config=bucket=terraform-state-bucket` to `terraform init`, then you would do the following:
+
+```sh
+export TF_CLI_INIT_BACKEND_CONFIG_BUCKET=terraform-state-bucket
+```
+
+Running `tfenv` will populate the `TF_CLI_ARGS_init=-backend-config=bucket=terraform-state-bucket`
+
+Multiple arguments can be specified and they will be properly concatenated.
+
+### Initializing Modules
+
+Terraform as the built-in capability to initialize "root modules" from a remote sources by passing the `-from-module` argument to `terraform init`.
+
+We can turn this into a 12-factor style invocation using `tfenv`.
+
+```sh
+export TF_CLI_INIT_FROM_MODULE=git::git@github.com:ImpactHealthio/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
+source <(tfenv)
+terraform init
+```
+
+Learn more about `TF_CLI_ARGS` and `TF_CLI_ARGS_*` in the [official documentation](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name).
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -59,24 +59,6 @@ introduction: |-
 
   With `tfenv` we can surgically assign a value to any terraform argument using per-argument environment variables.
 
-  For example, if you want to pass `-backend-config=bucket=terraform-state-bucket` to `terraform init`, then you would do the following:
-
-  ```
-  export TF_CLI_INIT_BACKEND_CONFIG_BUCKET=terraform-state-bucket
-  ```
-
-  Running `tfenv` will populate the `TF_CLI_ARGS_init=-backend-config=bucket=terraform-state-bucket`
-
-  Multiple arguments can be specified.
-
-  ```
-  export TF_CLI_INIT_FROM_MODULE=git::git@github.com:ImpactHealthio/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
-  source <(tfenv)
-  terraform init
-  ```
-
-  Learn more about `TF_CLI_ARGS` and `TF_CLI_ARGS_*` in the [official documentation](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name).
-
 
 # How to use this project
 usage: |-
@@ -96,8 +78,58 @@ usage: |-
   So for example, we can pass our current environment to terraform by simply running:
 
   ```sh
-      tfenv terraform plan
+  tfenv terraform plan
   ```
+
+  ### Direnv
+  
+  You can use `tfenv` with direnv very easily. Running `tfenv` without any arguments will emit `export` statements.
+
+  Example `.envrc`:
+
+  ```sh
+  # Export terraform environment
+  tfenv
+  ```
+
+  ### Bash
+  
+  Load the terraform environment into your shell.
+
+  Just add the following into your shell script:
+
+  ```sh
+  source <(tfenv)
+  ```
+
+  ### Terraform Args
+  
+  With `tfenv` we can populate the [`TF_CLI_ARGS` and `TF_CLI_ARGS_*` environment variables](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name) automatically. This makes it easy to toggle settings. 
+
+  For example, if you want to pass `-backend-config=bucket=terraform-state-bucket` to `terraform init`, then you would do the following:
+
+  ```sh
+  export TF_CLI_INIT_BACKEND_CONFIG_BUCKET=terraform-state-bucket
+  ```
+
+  Running `tfenv` will populate the `TF_CLI_ARGS_init=-backend-config=bucket=terraform-state-bucket`
+
+  Multiple arguments can be specified and they will be properly concatenated.
+
+  ### Initializing Modules
+  
+  Terraform as the built-in capability to initialize "root modules" from a remote sources by passing the `-from-module` argument to `terraform init`.
+
+  We can turn this into a 12-factor style invocation using `tfenv`.
+
+  ```sh
+  export TF_CLI_INIT_FROM_MODULE=git::git@github.com:ImpactHealthio/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
+  source <(tfenv)
+  terraform init
+  ```
+
+  Learn more about `TF_CLI_ARGS` and `TF_CLI_ARGS_*` in the [official documentation](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name).
+
 
 related:
   - name: "Packages"

--- a/README.yaml
+++ b/README.yaml
@@ -121,7 +121,7 @@ usage: |-
 
   ### Initializing Modules
   
-  Terraform as the built-in capability to initialize "root modules" from a remote sources by passing the `-from-module` argument to `terraform init`.
+  Terraform has the built-in capability to initialize "root modules" from a remote sources by passing the `-from-module` argument to `terraform init`.
 
   We can turn this into a 12-factor style invocation using `tfenv`.
 

--- a/README.yaml
+++ b/README.yaml
@@ -30,9 +30,12 @@ badges:
 
 # Short description of this project
 description: |-
-  Command line utility to transform environment variables for use with Terraform (e.g. `HOSTNAME` → `TF_VAR_hostname`)
+  Command line utility to transform environment variables for use with Terraform.
+  (e.g. `HOSTNAME` → `TF_VAR_hostname`)
+ 
+  It can also intelligently map environment variables to terraform command line arguments (e.g. `TF_CLI_INIT_BACKEND_CONFIG_BUCKET=example` → `TF_CLI_ARGS_init=-backend-config=bucket=example`).
 
-  __NOTE__: `tfenv` is **not** a [terraform version manager](https://github.com/tfutils/tfenv).
+  __NOTE__: `tfenv` is **not** a [terraform version manager](https://github.com/tfutils/tfenv). It strictly manages environment variables.
 
 introduction: |-
 

--- a/README.yaml
+++ b/README.yaml
@@ -41,6 +41,7 @@ introduction: |-
   * Have you ever wished you could easily pass environment variables to terraform *without* adding the `TF_VAR_` prefix?
   * Do you use [`chamber`](https://github.com/segmentio/chamber) and get annoyed when it transforms environment variables to uppercase?
   * Would you like to use common environment variables names with terraform? (e.g. `USER` or `AWS_REGION`)
+  * Is there some argument to `terraform init` you want to specify with an environment variable? (e.g. a `-backend-config` property)
 
   **Yes?** Great! Then this utility is for you.
 
@@ -52,6 +53,29 @@ introduction: |-
     4. Prepend prefix (`TF_VAR_`)
 
   __NOTE__: `tfenv` will preserve the existing environment and add the new environment variables with `TF_VAR_`. This is because some terraform providers expect non-`TF_VAR_*` prefixed environment variables. Additionally, when using the `local-exec` provisioner, it's convenient to use regular environment variables. See our [`terraform-null-smtp-mail`](https://github.com/cloudposse/terraform-null-smtp-mail) module for an example of using this pattern.
+
+
+  **But wait, there's more!**
+
+  With `tfenv` we can surgically assign a value to any terraform argument using per-argument environment variables.
+
+  For example, if you want to pass `-backend-config=bucket=terraform-state-bucket` to `terraform init`, then you would do the following:
+
+  ```
+  export TF_CLI_INIT_BACKEND_CONFIG_BUCKET=terraform-state-bucket
+  ```
+
+  Running `tfenv` will populate the `TF_CLI_ARGS_init=-backend-config=bucket=terraform-state-bucket`
+
+  Multiple arguments can be specified.
+
+  ```
+  export TF_CLI_INIT_FROM_MODULE=git::git@github.com:ImpactHealthio/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
+  source <(tfenv)
+  terraform init
+  ```
+
+  Learn more about `TF_CLI_ARGS` and `TF_CLI_ARGS_*` in the [official documentation](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name).
 
 
 # How to use this project


### PR DESCRIPTION
## what
* Map `TF_CLI_` style args to `TF_CLI_ARGS_*`

## why
* Allow individual terraform parameters to be set using environment variables
* 12 Factor friendly
* Terraform does not consistently support environment variables

## references
* https://github.com/hashicorp/terraform/issues/19300#issuecomment-436364376
* https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name

## how

This tool looks for environment variable names with a particular format and then populates `TF_CLI_ARGS` and `TF_CLI_ARGS_name` accordingly. Multiple arguments are concatenated. 

## use-case

With `tfenv` we can surgically assign a value to any terraform argument using environment variables.

```
TF_CLI_INIT_BACKEND_CONFIG_BUCKET=terraform-state-bucket
```
Using this technique, `tfenv` will populate the `TF_CLI_ARGS_init=-backend-config=bucket=terraform-state-bucket`

Multiple arguments can be specified.

```
export TF_CLI_INIT_FROM_MODULE=git::git@github.com:cloudposse/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
source <(tfenv)
terraform init
```