### PR TITLE
Add history

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Check out these related projects.
 - [build-harness](https://github.com/cloudposse/build-harness) - Collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more
 - [geodesic](https://github.com/cloudposse/geodesic) - Geodesic is the fastest way to get up and running with a rock solid, production grade cloud platform built on strictly Open Source tools.
 - [direnv](https://direnv.net/) - Unclutter your .profile with an environment switcher for the shell
-- [env](https://en.wikipedia.org/wiki/Env) - It is used to either print a list of environment variables or run another utility in an altered environment without having to modify the currently existing environment.
+- [env](https://en.wikipedia.org/wiki/Env) - Used to either print a list of environment variables or run another utility in an altered environment without having to modify the currently existing environment.
 
 
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ With `tfenv` we can surgically assign a value to any terraform argument using pe
 
 **Why is this project called `tfenv`?**
 
-This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime after 2010. 
+This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ __NOTE__: The utility supports a number of configuration settings which can be p
 The basic usage looks like this. We're going to run some `command` and pass it `arg1` ... `argN`:
 
 ```sh
-    tfenv command arg1 arg2 arg3 ... argN
+tfenv command arg1 arg2 arg3 ... argN
 ```
 
 So for example, we can pass our current environment to terraform by simply running:
@@ -89,13 +89,13 @@ tfenv terraform plan
 
 ### Direnv
 
-You can use `tfenv` with direnv very easily. Running `tfenv` without any arguments will emit `export` statements.
+You can use `tfenv` with [`direnv`](https://direnv.net/) very easily. Running `tfenv` without any arguments will emit `export` statements.
 
 Example `.envrc`:
 
 ```sh
 # Export terraform environment
-tfenv
+source <(tfenv)
 ```
 
 ### Bash
@@ -124,12 +124,12 @@ Multiple arguments can be specified and they will be properly concatenated.
 
 ### Initializing Modules
 
-Terraform as the built-in capability to initialize "root modules" from a remote sources by passing the `-from-module` argument to `terraform init`.
+Terraform has the built-in capability to initialize "root modules" from a remote sources by passing the `-from-module` argument to `terraform init`.
 
 We can turn this into a 12-factor style invocation using `tfenv`.
 
 ```sh
-export TF_CLI_INIT_FROM_MODULE=git::git@github.com:ImpactHealthio/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
+export TF_CLI_INIT_FROM_MODULE=git::https://github.com/cloudposse/terraform-root-modules.git//aws/tfstate-backend?ref=tags/x.y.z
 source <(tfenv)
 terraform init
 ```
@@ -172,14 +172,14 @@ You can easily integrate `tfenv` with [`direnv`](https://github.com/direnv/diren
 
 Add the following to your `.envrc`:
 
-```
-eval $(tfenv sh -c "export -p")
+```sh
+source <(tfenv)
 ```
 
 <details>
   <summary>Example Output</summary>
 
-  ```
+  ```sh
   direnv: loading .envrc
   direnv: export +TF_VAR_aws_profile +TF_VAR_aws_vault_backend +TF_VAR_colorterm +TF_VAR_dbus_session_bus_address +TF_VAR_desktop_session +TF_VAR_direnv_diff +TF_VAR_direnv_in_envrc +TF_VAR_direnv_watches +TF_VAR_display +TF_VAR_fzf_orig_completion_git +TF_VAR_github_token +TF_VAR_gtk_overlay_scrolling +TF_VAR_histcontrol +TF_VAR_histsize +TF_VAR_home +TF_VAR_hostname +TF_VAR_lang +TF_VAR_lessopen +TF_VAR_logname +TF_VAR_ls_colors +TF_VAR_mail +TF_VAR_mate_desktop_session_id +TF_VAR_okta_user +TF_VAR_oldpwd +TF_VAR_path +TF_VAR_pwd +TF_VAR_qt_auto_screen_scale_factor +TF_VAR_qt_scale_factor +TF_VAR_session_manager +TF_VAR_sessiontype +TF_VAR_shell +TF_VAR_shlvl +TF_VAR_ssh_auth_sock +TF_VAR_term +TF_VAR_user +TF_VAR_vte_version +TF_VAR_windowid +TF_VAR_xauthority +TF_VAR_xdg_current_desktop +TF_VAR_xdg_runtime_dir +TF_VAR_xdg_seat +TF_VAR_xdg_session_id +TF_VAR_xdg_vtnr
   ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ With `tfenv` we can surgically assign a value to any terraform argument using pe
 
 **Why is this project called `tfenv`?**
 
-This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
+This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. 
+
+The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ Check out these related projects.
 
 
 
+
+## References
+
+For additional context, refer to some of these links. 
+
+- [Terraform Without Wrappers is AWESOME!](https://www.reddit.com/r/Terraform/comments/afznb2/terraform_without_wrappers_is_awesome/) - Reddit discussion regarding this project.
+
+
 ## Help
 
 **Got a question?**

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ With `tfenv` we can surgically assign a value to any terraform argument using pe
 
 This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. 
 
-The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
+The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al., which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Command line utility to transform environment variables for use with Terraform.
 
 It can also intelligently map environment variables to terraform command line arguments (e.g. `TF_CLI_INIT_BACKEND_CONFIG_BUCKET=example` → `TF_CLI_ARGS_init=-backend-config=bucket=example`).
 
-__NOTE__: `tfenv` is **not** a [terraform version manager](https://github.com/tfutils/tfenv). It strictly manages environment variables.
+__NOTE__: `tfenv` is **not** a [terraform version manager](#history). It strictly manages environment variables much like `env` or `direnv`.
 
 
 ---
@@ -211,6 +211,8 @@ Check out these related projects.
 - [Packages](https://github.com/cloudposse/packages) - Cloud Posse installer and distribution of native apps
 - [build-harness](https://github.com/cloudposse/build-harness) - Collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more
 - [geodesic](https://github.com/cloudposse/geodesic) - Geodesic is the fastest way to get up and running with a rock solid, production grade cloud platform built on strictly Open Source tools.
+- [direnv](https://direnv.net/) - Unclutter your .profile with an environment switcher for the shell
+- [env](https://en.wikipedia.org/wiki/Env) - It is used to either print a list of environment variables or run another utility in an altered environment without having to modify the currently existing environment.
 
 
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ __NOTE__: `tfenv` will preserve the existing environment and add the new environ
 
 With `tfenv` we can surgically assign a value to any terraform argument using per-argument environment variables.
 
+## History
+
+
+**Why is this project called `tfenv`?**
+
+This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime after 2010. 
+
 ## Usage
 
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ With `tfenv` we can surgically assign a value to any terraform argument using pe
 
 This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. 
 
-The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al., which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
+The `env` command has been [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al., which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
 
 ## Usage
 

--- a/README.yaml
+++ b/README.yaml
@@ -62,6 +62,12 @@ introduction: |-
 
   With `tfenv` we can surgically assign a value to any terraform argument using per-argument environment variables.
 
+  ## History
+  
+
+  **Why is this project called `tfenv`?**
+
+  This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime after 2010. 
 
 # How to use this project
 usage: |-

--- a/README.yaml
+++ b/README.yaml
@@ -67,7 +67,9 @@ introduction: |-
 
   **Why is this project called `tfenv`?**
 
-  This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
+  This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. 
+  
+  The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
 
 # How to use this project
 usage: |-

--- a/README.yaml
+++ b/README.yaml
@@ -35,7 +35,7 @@ description: |-
  
   It can also intelligently map environment variables to terraform command line arguments (e.g. `TF_CLI_INIT_BACKEND_CONFIG_BUCKET=example` → `TF_CLI_ARGS_init=-backend-config=bucket=example`).
 
-  __NOTE__: `tfenv` is **not** a [terraform version manager](https://github.com/tfutils/tfenv). It strictly manages environment variables.
+  __NOTE__: `tfenv` is **not** a [terraform version manager](#history). It strictly manages environment variables much like `env` or `direnv`.
 
 introduction: |-
 
@@ -150,6 +150,12 @@ related:
   - name: "geodesic"
     description: "Geodesic is the fastest way to get up and running with a rock solid, production grade cloud platform built on strictly Open Source tools."
     url: "https://github.com/cloudposse/geodesic"
+  - name: "direnv"
+    description: "Unclutter your .profile with an environment switcher for the shell"
+    url: "https://direnv.net/"
+  - name: "env"
+    description: "It is used to either print a list of environment variables or run another utility in an altered environment without having to modify the currently existing environment."
+    url: "https://en.wikipedia.org/wiki/Env"
 
 examples: |-
 

--- a/README.yaml
+++ b/README.yaml
@@ -140,6 +140,11 @@ usage: |-
   Learn more about `TF_CLI_ARGS` and `TF_CLI_ARGS_*` in the [official documentation](https://www.terraform.io/docs/configuration/environment-variables.html#tf_cli_args-and-tf_cli_args_name).
 
 
+references:
+  - name: "Terraform Without Wrappers is AWESOME!"
+    description: "Reddit discussion regarding this project."
+    url: "https://www.reddit.com/r/Terraform/comments/afznb2/terraform_without_wrappers_is_awesome/"
+
 related:
   - name: "Packages"
     description: "Cloud Posse installer and distribution of native apps"

--- a/README.yaml
+++ b/README.yaml
@@ -69,7 +69,7 @@ introduction: |-
 
   This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. 
   
-  The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al., which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
+  The `env` command has been [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al., which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
 
 # How to use this project
 usage: |-

--- a/README.yaml
+++ b/README.yaml
@@ -69,7 +69,7 @@ introduction: |-
 
   This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. 
   
-  The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
+  The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al., which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
 
 # How to use this project
 usage: |-

--- a/README.yaml
+++ b/README.yaml
@@ -75,7 +75,7 @@ usage: |-
   The basic usage looks like this. We're going to run some `command` and pass it `arg1` ... `argN`:
 
   ```sh
-      tfenv command arg1 arg2 arg3 ... argN
+  tfenv command arg1 arg2 arg3 ... argN
   ```
 
   So for example, we can pass our current environment to terraform by simply running:
@@ -86,13 +86,13 @@ usage: |-
 
   ### Direnv
   
-  You can use `tfenv` with direnv very easily. Running `tfenv` without any arguments will emit `export` statements.
+  You can use `tfenv` with [`direnv`](https://direnv.net/) very easily. Running `tfenv` without any arguments will emit `export` statements.
 
   Example `.envrc`:
 
   ```sh
   # Export terraform environment
-  tfenv
+  source <(tfenv)
   ```
 
   ### Bash
@@ -126,7 +126,7 @@ usage: |-
   We can turn this into a 12-factor style invocation using `tfenv`.
 
   ```sh
-  export TF_CLI_INIT_FROM_MODULE=git::git@github.com:ImpactHealthio/terraform-root-modules.git//aws/$(SERVICE)?ref=tags/0.5.7
+  export TF_CLI_INIT_FROM_MODULE=git::https://github.com/cloudposse/terraform-root-modules.git//aws/tfstate-backend?ref=tags/x.y.z
   source <(tfenv)
   terraform init
   ```
@@ -177,14 +177,14 @@ examples: |-
 
   Add the following to your `.envrc`:
 
-  ```
-  eval $(tfenv sh -c "export -p")
+  ```sh
+  source <(tfenv)
   ```
 
   <details>
     <summary>Example Output</summary>
 
-    ```
+    ```sh
     direnv: loading .envrc
     direnv: export +TF_VAR_aws_profile +TF_VAR_aws_vault_backend +TF_VAR_colorterm +TF_VAR_dbus_session_bus_address +TF_VAR_desktop_session +TF_VAR_direnv_diff +TF_VAR_direnv_in_envrc +TF_VAR_direnv_watches +TF_VAR_display +TF_VAR_fzf_orig_completion_git +TF_VAR_github_token +TF_VAR_gtk_overlay_scrolling +TF_VAR_histcontrol +TF_VAR_histsize +TF_VAR_home +TF_VAR_hostname +TF_VAR_lang +TF_VAR_lessopen +TF_VAR_logname +TF_VAR_ls_colors +TF_VAR_mail +TF_VAR_mate_desktop_session_id +TF_VAR_okta_user +TF_VAR_oldpwd +TF_VAR_path +TF_VAR_pwd +TF_VAR_qt_auto_screen_scale_factor +TF_VAR_qt_scale_factor +TF_VAR_session_manager +TF_VAR_sessiontype +TF_VAR_shell +TF_VAR_shlvl +TF_VAR_ssh_auth_sock +TF_VAR_term +TF_VAR_user +TF_VAR_vte_version +TF_VAR_windowid +TF_VAR_xauthority +TF_VAR_xdg_current_desktop +TF_VAR_xdg_runtime_dir +TF_VAR_xdg_seat +TF_VAR_xdg_session_id +TF_VAR_xdg_vtnr
     ```

--- a/README.yaml
+++ b/README.yaml
@@ -154,7 +154,7 @@ related:
     description: "Unclutter your .profile with an environment switcher for the shell"
     url: "https://direnv.net/"
   - name: "env"
-    description: "It is used to either print a list of environment variables or run another utility in an altered environment without having to modify the currently existing environment."
+    description: "Used to either print a list of environment variables or run another utility in an altered environment without having to modify the currently existing environment."
     url: "https://en.wikipedia.org/wiki/Env"
 
 examples: |-

--- a/README.yaml
+++ b/README.yaml
@@ -67,7 +67,7 @@ introduction: |-
 
   **Why is this project called `tfenv`?**
 
-  This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. which are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime after 2010. 
+  This `tfenv` project borrows it's naming convention from popular tools like [`env`](https://en.wikipedia.org/wiki/Env), [`direnv`](http://direnv.net), and [`autoenv`](https://github.com/kennethreitz/autoenv). These tools provide various ways to export variables in the environment. The `env` command has been in [around since the early 90s](http://pdplab.it.uom.gr/project/sysadm/unix.pdf), while [environment variables](https://en.wikipedia.org/wiki/Environment_variable) were first conceived of in 1979. On the other hand there are tools like `rbenv` Et al. are ["version managers"](https://en.wikipedia.org/wiki/Ruby_Version_Manager) that were conceived of sometime around 2010.
 
 # How to use this project
 usage: |-


### PR DESCRIPTION
## what
* Document history of `env` tools

## why
* There's some confusion about the naming of `tfenv` relative to another similarly named project called [`tfenv`](https://github.com/tfutils/tfenv), which borrows on [`rbenv`](https://github.com/rbenv/rbenv).
## references
* closes #6 